### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snd.yml
+++ b/.github/workflows/snd.yml
@@ -9,6 +9,8 @@ on:
       - 'images/**'
       - '.github/copilot-instructions.md'
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/chvvkumar/simpleCloudDetect/security/code-scanning/8](https://github.com/chvvkumar/simpleCloudDetect/security/code-scanning/8)

To fix the problem, add an explicit `permissions` block with least privilege to your workflow. Since the steps in this job only require read access to repository contents (for checkout), it is sufficient and best to add `permissions: contents: read` to the root of the workflow file, at the same indentation as `name` and `on`, so that it applies to all jobs unless overridden. No functional changes to steps are required. Insert the permissions block before the `jobs:` key for clarity and convention.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
