### PR TITLE
Make MQTT and Home Assistant settings optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,33 @@
 docker-compose.yaml
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Logs
+*.log

--- a/tests/test_config_optional_mqtt.py
+++ b/tests/test_config_optional_mqtt.py
@@ -1,0 +1,70 @@
+import os
+import unittest
+from unittest.mock import patch
+from detect import Config
+
+class TestConfigOptionalMqtt(unittest.TestCase):
+
+    def setUp(self):
+        # Clear relevant environment variables before each test
+        self.env_vars = {
+            'IMAGE_URL': 'http://example.com/image.jpg',
+            'DETECT_INTERVAL': '60',
+            'MQTT_BROKER': '',
+            'MQTT_PORT': '',
+            'MQTT_TOPIC': '',
+            'MQTT_USERNAME': '',
+            'MQTT_PASSWORD': '',
+            'MQTT_DISCOVERY_MODE': '',
+            'DEVICE_ID': ''
+        }
+        self.patcher = patch.dict(os.environ, self.env_vars)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_config_no_mqtt(self):
+        """Test that Config can be initialized without MQTT settings."""
+        # Ensure MQTT variables are unset/empty
+        if 'MQTT_BROKER' in os.environ:
+            del os.environ['MQTT_BROKER']
+            
+        config = Config.from_env()
+        
+        self.assertIsNone(config.broker)
+        self.assertIsNone(config.topic)
+        self.assertEqual(config.image_url, 'http://example.com/image.jpg')
+
+    def test_config_with_mqtt(self):
+        """Test that Config is initialized correctly with MQTT settings."""
+        os.environ['MQTT_BROKER'] = 'mqtt.example.com'
+        os.environ['MQTT_TOPIC'] = 'test/topic'
+        
+        config = Config.from_env()
+        
+        self.assertEqual(config.broker, 'mqtt.example.com')
+        self.assertEqual(config.topic, 'test/topic')
+
+    def test_config_legacy_mode_missing_topic(self):
+        """Test that legacy mode requires topic only if broker is set."""
+        os.environ['MQTT_BROKER'] = 'mqtt.example.com'
+        os.environ['MQTT_DISCOVERY_MODE'] = 'legacy'
+        # MQTT_TOPIC is missing
+        
+        with self.assertRaises(ValueError) as cm:
+            Config.from_env()
+        self.assertIn("Missing required environment variables", str(cm.exception))
+
+    def test_config_ha_mode_missing_device_id(self):
+        """Test that HA mode requires DEVICE_ID only if broker is set."""
+        os.environ['MQTT_BROKER'] = 'mqtt.example.com'
+        os.environ['MQTT_DISCOVERY_MODE'] = 'homeassistant'
+        # DEVICE_ID is missing
+        
+        with self.assertRaises(ValueError) as cm:
+            Config.from_env()
+        self.assertIn("DEVICE_ID is required", str(cm.exception))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION


### 📋 Overview
This pull request enhances the application by making MQTT and Home Assistant configuration settings optional. It modifies the core detection logic to gracefully handle the absence of these settings, allowing the application to run without them. New tests have been added to validate this optionality.

### 🔄 Changes by Category
*   **Features**:
    *   Modified `detect.py` to update configuration parsing, making MQTT and Home Assistant related settings optional.
*   **Tests**:
    *   Added a new test file `tests/test_config_optional_mqtt.py` to specifically test the behavior of the application when MQTT and Home Assistant settings are not provided.
*   **Configuration**:
    *   Updated `.gitignore` to include additional patterns for files and directories to be ignored by version control.

---
<sub>📊 Analyzed **1** commit(s) | 🕐 Updated: 2026-01-05T15:33:54.348Z | Generated by GitHub Actions</sub>

---

